### PR TITLE
Only remove the DBRepair TMPDIR, fix a typo

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -338,8 +338,7 @@ HostConfig() {
                     cat override.conf local.conf *.conf 2>/dev/null | grep "APPLICATION_SUPPORT_DIR" | head -1)"
 
       if [ "$NewSuppDir" != "" ]; then
-        NewSuppDir="${NewSuppDir//[^=]*=/}"
-        NewSuppDir="${AppSuppDir//\"}"
+        NewSuppDir="$(sed -e 's/.*_DIR=//' | tr -d '"' | tr -d "'"
 
         if [ -d "$NewSuppDir" ]; then
           AppSuppDir="$NewSuppDir"

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -464,7 +464,7 @@ touch "$LOGFILE"
 if [ ! -f "$PLEX_SQLITE" ] ; then
   Output "PMS is not installed.  Cannot continue.  Exiting."
   WriteLog "Attempt to run utility without PMS installed."
-  rm -rf $TMPDIR
+  [ -d "$DBDIR/dbtmp" ] && rm -rf "$DBDIR/dbtmp"
   exit 1
 fi
 
@@ -481,7 +481,7 @@ if [ ! -f "$DBDIR/$CPPL.db" ]       && \
 
   Output "Cannot locate databases. Cannot continue.  Exiting."
   WriteLog "No databases or backups found."
-  rm -rf $TMPDIR
+  [ -d "$DBDIR/dbtmp" ] && rm -rf "$DBDIR/dbtmp"
   exit 1
 fi
 
@@ -627,7 +627,7 @@ do
       Output "Vacuuming blobs database successful (Size: ${SizeStart}MB/${SizeFinish}MB)."
       WriteLog "Vacuum  - Vacuum blobs database - PASS (Size: ${SizeStart}MB/${SizeFinish}MB)."
     else
-      OutMBput "Vaccuming blobs database failed. Error code $Result from Plex SQLite"
+      Output "Vaccuming blobs database failed. Error code $Result from Plex SQLite"
       WriteLog "Vacuum  - Vacuum blobs database - FAIL ($Result)"
       Fail=1
     fi


### PR DESCRIPTION
This commit changes behavior to add a more accurate directory specification:

- At line 467 and 484 TMPDIR has not yet been set by the script.
- But on some hosts TMPDIR could be in use and could be the system temp.
- So only remove the DBRepair TMPDIR if any.
- During the graceful exit at line 1073, the DBRepair TMPDIR has been set, and no changes were needed.

Q: Should the script capture TMPDIR and TMP before exporting those at line 521? This reminds me of an IFS and OIFS situation, but I don't understand environments well enough.

Also fixed some OutKAput while dusting off my 2bits account. 😃