### PR TITLE
Fix echo variable pipe for NewSuppDir

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -338,7 +338,7 @@ HostConfig() {
                     cat override.conf local.conf *.conf 2>/dev/null | grep "APPLICATION_SUPPORT_DIR" | head -1)"
 
       if [ "$NewSuppDir" != "" ]; then
-        NewSuppDir="$(sed -e 's/.*_DIR=//' | tr -d '"' | tr -d "'")"
+        NewSuppDir="$(echo $NewSuppDir | sed -e 's/.*_DIR=//' | tr -d '"' | tr -d "'")"
 
         if [ -d "$NewSuppDir" ]; then
           AppSuppDir="$NewSuppDir"


### PR DESCRIPTION
Fixes: https://github.com/ChuckPa/PlexDBRepair/issues/3

This commit fixes a `NewSuppDir` bug reported in the forum SQLite3 thread, https://forums.plex.tv/t/suggested-sqlite3-db-optimizations/794749/122 where a `sed` was missing its `echo` variable and pipe.

The code between lines 328 and 350 was cut and tested in a Bourne script on a Mac, but not the whole `DBRepair.sh` on the user's OS. There's no real need to pull this, as it's not for extra credit :)  But it get's the word out, and gives me chance to test if using my fork/branch plus PR and GHI number is in the format that was requested.