### PR TITLE
Add watchlist (viewstate) import support to utility

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -186,7 +186,7 @@ ConfirmYesNo() {
   Answer=""
   while [ "$Answer" = "" ]
   do
-    echo -n "$1 (Y/N) ? "
+    printf "$1 (Y/N) ? "
     read Input
 
     # EOF = No
@@ -209,7 +209,7 @@ ConfirmYesNo() {
   Answer=""
   while [ "$Answer" = "" ]
   do
-    echo -n "Are you sure (Y/N) ? "
+    printf "Are you sure (Y/N) ? "
     read Input
 
     # EOF = No
@@ -524,7 +524,7 @@ do
     echo "  8. Show logfile"
     echo "  9. Exit"
     echo " "
-    echo -n "Enter choice: "
+    printf "Enter choice: "
     if [ "$1" != "" ]; then
       Input="$1"
       echo "$1"
@@ -746,7 +746,7 @@ do
     Owner="$(stat -c '%u:%g' $CPPL.db)"
 
     # Attempt to export main db to SQL file (Step 1)
-    echo -n  'Export: (main)..'
+    printf  'Export: (main)..'
     "$PLEX_SQLITE" $CPPL.db  ".output '$TMPDIR/library.plexapp.sql-$TimeStamp'" .dump
     Result=$?
     if ! SQLiteOK $Result; then
@@ -760,7 +760,7 @@ do
     fi
 
     # Attempt to export blobs db to SQL file
-    echo -n '(blobs)..'
+    printf '(blobs)..'
     "$PLEX_SQLITE" $CPPL.blobs.db  ".output '$TMPDIR/blobs.plexapp.sql-$TimeStamp'" .dump
     Result=$?
     if ! SQLiteOK $Result; then
@@ -787,7 +787,7 @@ do
     WriteLog "Repair  - Export databases - PASS"
 
     # Library and blobs successfully exported, create new
-    echo -n 'Import: (main)..'
+    printf 'Import: (main)..'
     "$PLEX_SQLITE" $CPPL.db-$TimeStamp < "$TMPDIR/library.plexapp.sql-$TimeStamp"
     Result=$?
     if ! SQLiteOK $Result; then
@@ -798,7 +798,7 @@ do
       continue
     fi
 
-    echo -n '(blobs)..'
+    printf '(blobs)..'
     "$PLEX_SQLITE" $CPPL.blobs.db-$TimeStamp < "$TMPDIR/blobs.plexapp.sql-$TimeStamp"
     Result=$?
     if ! SQLiteOK $Result ; then
@@ -1075,7 +1075,7 @@ do
     fi
 
     # Check the given database
-    if ! CheckDB "$Input" 2>1 >/dev/null; then
+    if ! CheckDB "$Input"; then
       Output "Error:  Given database is damaged.  Repair needed. Database not trusted.  Refusing to import."
       continue
     fi

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -1112,17 +1112,16 @@ do
 
     # Import viewstates into working copy
     Output "Importing Viewstate data"
-    "$PLEX_SQLITE" $CPPL.db < "$TMPDIR/Viewstate.sql-$TimeStamp"
-    Result=$?
+    "$PLEX_SQLITE" $CPPL.db < "$TMPDIR/Viewstate.sql-$TimeStamp 2> /dev/null"
 
     # Make certain the resultant DB is OK
     Output "Checking database following import"
-    if ! CheckDB $CPPL.db ; then
 
+    if ! CheckDB $CPPL.db ; then
       Output "Error $Result during import.  Import corrupted database."
       Output "      Undoing viewstate import."
 
-      RestoreSaved "$LastTimestamp"
+      cp -p "$TMPDIR/Viewstate.db-$TimeStamp" $CPPL.db
       WriteLog "Import  - Import: $Input - FAIL"
       continue
     fi

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -1112,7 +1112,7 @@ do
 
     # Import viewstates into working copy
     Output "Importing Viewstate data"
-    "$PLEX_SQLITE" $CPPL.db < "$TMPDIR/Viewstate.sql-$TimeStamp 2> /dev/null"
+    "$PLEX_SQLITE" $CPPL.db < "$TMPDIR/Viewstate.sql-$TimeStamp" 2> /dev/null
 
     # Make certain the resultant DB is OK
     Output "Checking database following import"

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -1101,7 +1101,7 @@ do
     echo ".dump metadata_item_settings" | "$PLEX_SQLITE" "$Input" | grep -v TABLE | grep -v INDEX > "$TMPDIR/Viewstate.sql-$TimeStamp"
 
     # Make certain we got something usable
-    if [ $(wc -l "$TMPDIR/Viewstate.sql-$TimeStamp" | cut -d " " -f 1) -lt 1 ]; then
+    if [ $(wc -l "$TMPDIR/Viewstate.sql-$TimeStamp" | awk '{print $1}') -lt 1 ]; then
       Output "No viewstates found to import."
       continue
     fi

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -440,7 +440,7 @@ SetLast() {
 CPPL=com.plexapp.plugins.library
 
 # Initial timestamp
-TimeStamp="$(date "+%Y-%m-%d_%H:%M:%S")"
+TimeStamp="$(date "+%Y-%m-%d_%H.%M.%S")"
 
 # Initialize LastName LastTimestamp
 SetLast "" ""
@@ -1056,7 +1056,7 @@ do
   # 7.  - Get Viewstate/Watch history from another DB and import
   elif [ $Choice -eq 7 ]; then
 
-    echo -n "Pathname of database containing watch history to import: "
+    printf "Pathname of database containing watch history to import: "
     read Input
 
     # Did we get something?


### PR DESCRIPTION
Import watchlist  (metadata_items_settings) from one database into the current database.

This is useful when rebuilding from backups or replicating PMS on a new host.

Fixes: https://github.com/ChuckPa/PlexDBRepair/issues/5