### PR TITLE
Changes to support MacOS

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -432,7 +432,7 @@ HostConfig() {
     PLEX_SQLITE="/Applications/Plex Media Server.app/Contents/MacOS/Plex SQLite"
     AppSuppDir="$HOME/Library/Application Support"
     DBDIR="$AppSuppDir/Plex Media Server/Plug-in Support/Databases"
-    PID_FILE="$AppSuppDir/Plex Media Server/plexmediaserver.pid"
+    PID_FILE="$DBDIR/dbtmp/plexmediaserver.pid"
     LOGFILE="$DBDIR/DBRepair.log"
     LOG_TOOL="logger"
 
@@ -441,9 +441,13 @@ HostConfig() {
     STATFMT="-f"
     STATBYTES="%z"
 
-    # On MacOS PMS is not coded to create a plexmediaserver.pid.
-    # Remove stale, and if PMS is running create a new one for script use.
+    # make the TMP directory in advance to store plexmediaserver.pid
+    mkdir -p "$DBDIR/dbtmp"
+
+    # Remove stale PID file if it exists
     [ -f "$PID_FILE" ] && rm "$PID_FILE"
+
+    # If PMS is running create plexmediaserver.pid
     PIDVALUE=$($PIDOF "Plex Media Server")
     [ $PIDVALUE ] && echo $PIDVALUE > "$PID_FILE"
 

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -1102,7 +1102,7 @@ do
       continue
     fi
 
-    WriteLog "Import   - Attempting to import watch history from '$Input' "
+    WriteLog "Import  - Attempting to import watch history from '$Input' "
 
     # Confirm our databases are intact
     if ! CheckDatabases; then
@@ -1120,7 +1120,7 @@ do
 
     # Make a backup
     Output "Backing up databases"
-    if ! MakeBackups "Import  "; then
+    if ! MakeBackups "Import "; then
       Output "Error making backups.  Cannot continue."
       WriteLog "Import  - MakeBackups - FAIL"
       Fail=1

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -246,7 +246,7 @@ RestoreSaved() {
 # Get the size of the given DB in MB
 GetSize() {
 
-  Size=$(stat -c %s "$1")
+  Size=$(stat $STATFMT $STATBYTES "$1")
   Size=$(expr $Size / 1048576)
   [ $Size -eq 0 ] && Size=1
   echo $Size
@@ -254,6 +254,11 @@ GetSize() {
 
 # Determine which host we are running on and set variables
 HostConfig() {
+
+  # On all hosts except Mac
+  PIDOF="pidof"
+  STATFMT="-c"
+  STATBYTES="%s"
 
   # Synology (DSM 7)
   if [ -d /var/packages/PlexMediaServer ] && \
@@ -419,6 +424,31 @@ HostConfig() {
     HostType="Western Digital"
     return 0
 
+  # Apple Mac
+  elif [ -d "/Applications/Plex Media Server.app" ] && \
+       [ -d "$HOME/Library/Application Support/Plex Media Server" ]; then
+
+    # Where is the software
+    PLEX_SQLITE="/Applications/Plex Media Server.app/Contents/MacOS/Plex SQLite"
+    AppSuppDir="$HOME/Library/Application Support"
+    DBDIR="$AppSuppDir/Plex Media Server/Plug-in Support/Databases"
+    PID_FILE="$AppSuppDir/Plex Media Server/plexmediaserver.pid"
+    LOGFILE="$DBDIR/DBRepair.log"
+    LOG_TOOL="logger"
+
+    # MacOS uses pgrep and uses different stat options
+    PIDOF="pgrep"
+    STATFMT="-f"
+    STATBYTES="%z"
+
+    # On MacOS PMS is not coded to create a plexmediaserver.pid.
+    # Remove stale, and if PMS is running create a new one for script use.
+    [ -f "$PID_FILE" ] && rm "$PID_FILE"
+    PIDVALUE=$($PIDOF "Plex Media Server")
+    [ $PIDVALUE ] && echo $PIDVALUE > "$PID_FILE"
+
+    HostType="Mac"
+    return 0
   fi
 
   # Unknown / currently unsupported host
@@ -448,7 +478,7 @@ SetLast "" ""
 # Identify this host
 HostType="" ; LOG_TOOL="echo"
 if ! HostConfig; then
-  Output 'Error: Unknown host. Currently supported hosts are: QNAP, Synology, Netgear, ASUSTOR, WD (OS5) and Linux Workstation/Server'
+  Output 'Error: Unknown host. Currently supported hosts are: QNAP, Synology, Netgear, Mac, ASUSTOR, WD (OS5) and Linux Workstation/Server'
   exit 1
 fi
 
@@ -497,7 +527,7 @@ while true
 do
 
   # Is PMS already running?
-  if [ -f "$PID_FILE" ] && [ "$(pidof 'Plex Media Server')" != "" ] ; then
+  if [ -f "$PID_FILE" ] && [ "$($PIDOF 'Plex Media Server')" != "" ] ; then
     Output "Plex Media Server is currently running, cannot continue."
     Output "Please stop Plex Media Server and restart this utility."
     WriteLog "PMS running. Could not continue."
@@ -728,7 +758,7 @@ do
     fi
 
     # Check size
-    Size=$(stat -c '%s' $CPPL.db)
+    Size=$(stat $STATFMT $STATBYTES $CPPL.db)
 
     # Exit if not valid
     if [ $Size -lt 300000 ]; then
@@ -743,7 +773,7 @@ do
     Fail=0
 
     # Get the owning UID/GID before we proceed so we can restore
-    Owner="$(stat -c '%u:%g' $CPPL.db)"
+    Owner="$(stat $STATFMT '%u:%g' $CPPL.db)"
 
     # Attempt to export main db to SQL file (Step 1)
     printf  'Export: (main)..'
@@ -1044,7 +1074,7 @@ do
         done
 
         Output "Undo complete."
-        WriteLog "Undo    - Undo $LastName , TimeStamp $LastTimestamp"
+        WriteLog "Undo    - Undo ${LastName}, TimeStamp $LastTimestamp"
         SetLast "Undo" ""
       fi
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It is a simple menu-driven utility with a command line backend.
         5. Synology (DSM 6 & DSM 7)
         6. Docker (via 'docker exec' command line)
         7. Western Digital (OS5)
+        8. Apple (MacOS)
 
  ## How to install
 
@@ -48,6 +49,7 @@ It is a simple menu-driven utility with a command line backend.
     Western Digital    | Public              |  /mnt/HD/HD_a2/Public      (Does not support 'MyCloudHome' series)
     Docker             | N/A                 |  Container root (adjacent /config)
     Linux (wkstn/svr)  | N/A                 |  Anywhere
+    Apple              | Downloads           |  ~/Downloads
 ```
 ###    To install & launch:
         1. Place the tar/zip/sh file in the appropriate directory
@@ -79,6 +81,16 @@ It is a simple menu-driven utility with a command line backend.
         systemctl stop plexmediaserver
         cd /path/to/DBRepair.tar
         tar xf DBRepair.tar
+        ./DBRepair.sh
+```
+
+###    To launch in MacOS (on the administrator account)
+```
+        osascript -e 'quit app "Plex Media Server"'
+        cd ~/Downloads
+        tar xvf PlexDBRepair-0.3.4.tar.gz
+        cd PlexDBRepair-0.3.4
+        chmod +x DBRepair.sh
         ./DBRepair.sh
 ```
 


### PR DESCRIPTION
Fixes: #2 

This includes all the changes needed to make PlexDBRepair work on MacOS.
Take a look at the code, and let me know your thoughts.

Unresolved:
- On a Mac there's no `plexmediaserver.pid` so I decided to create one during `HostConfig()` - wrong place to do so?
- The logic to check whether PMS is running can be defeated on a Mac as written in this PR at this time, by starting PMS after DBRepair is running (because I would not have made a `pid` file in `HostConfig`). So that should be sorted out.
- a bit of spacing and cleanup

Ok then, G'day.
