### PR TITLE
Add start/stop command for ReadyNAS

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -447,6 +447,10 @@ HostConfig() {
       LOGFILE="$DBDIR/DBRepair.log"
       LOG_TOOL="logger"
 
+      HaveStartStop=1
+      StartCommand="systemctl start fvapp-plexmediaserver"
+      StopCommand="systemctl stop fvapp-plexmediaserver"
+
       HostType="Netgear ReadyNAS"
       return 0
     fi


### PR DESCRIPTION
I just tested this on my ReadyNAS 316, and it works.  The service file is stored at `/apps/plexmediaserver/fvapp-plexmediaserver.service`.