### PR TITLE
Support for Arch-based distributions

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -625,7 +625,7 @@ HostConfig() {
     fi
 
   # Arch Linux (must check for native Arch after binhex)
-  elif [ -e /etc/os-release ] &&  [ "$(grep 'Arch Linux' /etc/os-release)" != "" ] && \
+  elif [ -e /etc/os-release ] && { source /etc/os-release; ( [[ $ID == "arch" ]] || [[ $ID_LIKE == *"arch"* ]] ) } && \
        [ -d /usr/lib/plexmediaserver ] && \
        [ -d /var/lib/plex ]; then
 
@@ -656,7 +656,7 @@ HostConfig() {
     DBDIR="$AppSuppDir/Plex Media Server/Plug-in Support/Databases"
     LOGFILE="$DBDIR/DBRepair.log"
     LOG_TOOL="logger"
-    HostType="Arch Linux"
+    HostType="$PRETTY_NAME"
 
     HaveStartStop=1
     StartCommand="systemctl start plexmediaserver"


### PR DESCRIPTION
Fixes: https://github.com/ChuckPa/PlexDBRepair/issues/78

### Explanation of changes; 
 - source /etc/os-release
 - is $ID "arch"
 OR
 - does $ID_LIKE contain "arch"
 - HostType="$PRETTY_NAME" to use $PRETTY_NAME from /etc/os-release

### Test using the above changes: 
`cat /etc/os-release`
```.env
NAME="Manjaro Linux"
PRETTY_NAME="Manjaro Linux"
ID=manjaro
ID_LIKE=arch
BUILD_ID=rolling
ANSI_COLOR="32;1;24;144;200"
HOME_URL="https://manjaro.org/"
DOCUMENTATION_URL="https://wiki.manjaro.org/"
SUPPORT_URL="https://forum.manjaro.org/"
BUG_REPORT_URL="https://docs.manjaro.org/reporting-bugs/"
PRIVACY_POLICY_URL="https://manjaro.org/privacy-policy/"
LOGO=manjarolinux
```

```
2023-06-09 14.11.24 - ============================================================
2023-06-09 14.11.24 - Session start: Host is Manjaro Linux
2023-06-09 14.11.28 - Stop    - PASS
2023-06-09 14.12.54 - Auto    - START
2023-06-09 14.12.56 - Check   - Check com.plexapp.plugins.library.db - PASS
2023-06-09 14.12.57 - Check   - Check com.plexapp.plugins.library.blobs.db - PASS
2023-06-09 14.12.57 - Check   - PASS
2023-06-09 14.13.11 - Repair  - Export databases - PASS
2023-06-09 14.13.17 - Repair  - Import - PASS
2023-06-09 14.13.18 - Repair  - Verify main database - PASS (Size: 77MB/71MB).
2023-06-09 14.13.18 - Repair  - Verify blobs database - PASS (Size: 143MB/146MB).
2023-06-09 14.13.18 - Repair  - Move files - PASS
2023-06-09 14.13.18 - Repair  - PASS
2023-06-09 14.13.18 - Repair  - PASS
2023-06-09 14.13.18 - Reindex - MakeBackup com.plexapp.plugins.library.db - PASS
2023-06-09 14.13.18 - Reindex - MakeBackup com.plexapp.plugins.library.blobs.db - PASS
2023-06-09 14.13.18 - Reindex - MakeBackup - PASS
2023-06-09 14.13.19 - Reindex - Reindex: com.plexapp.plugins.library.db - PASS
2023-06-09 14.13.19 - Reindex - Reindex: com.plexapp.plugins.library.blobs.db - PASS
2023-06-09 14.13.19 - Reindex - PASS
2023-06-09 14.13.19 - Reindex - PASS
2023-06-09 14.13.19 - Auto    - COMPLETED
2023-06-09 14.13.35 - Exit    - Retain temp files.
```

Thanks!

