### PR TITLE
Fix not checking update confirmation

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -1931,7 +1931,7 @@ do
         GetLatestRelease
         if [ $(VersionDigits $LatestVersion) -gt $(VersionDigits $Version) ]; then
           [ $Scripted -eq 1 ] && DoUpdate=1
-          ConfirmYesNo "Download $Latest and update?" && DoUpdate=1
+          [ $Scripted -eq 0 ] && ConfirmYesNo "Download $Latest and update?" && DoUpdate=1
         else
           Output "No update available."
         fi


### PR DESCRIPTION
If `Scripted=1` the script still update itself if I enter N/n but now it won't ask for confirmation when arguments detected but only asks when arguments not detected.