### PR TITLE
Fix unable to repair DB when UNIQUE constraint errors occur

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -884,6 +884,7 @@ DoRepair() {
     Result=$?
     [ $IgnoreErrors -eq 1 ] && Result=0
 
+    if ! SQLiteOK $Result ; then
       Output "Error $Result from Plex SQLite while importing from '$TMPDIR/library.plexapp.sql-$TimeStamp'"
       WriteLog "Repair  - Cannot import main database from '$TMPDIR/library.plexapp.sql-$TimeStamp' - FAIL ($Result)"
       Output "Cannot continue."

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -2,12 +2,12 @@
 #########################################################################
 # Plex Media Server database check and repair utility script.           #
 # Maintainer: ChuckPa                                                   #
-# Version:    v1.01.03                                                  #
+# Version:    v1.01.04                                                  #
 # Date:       25-Nov-2023                                               #
 #########################################################################
 
 # Version for display purposes
-Version="v1.01.03"
+Version="v1.01.04"
 
 # Flag when temp files are to be retained
 Retain=0

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -8,7 +8,7 @@
 ![Maintenance](https://img.shields.io/badge/Maintained-Yes-green.svg)
 
 # Release Info:
-v1.01.03
+v1.01.04
 
   - Missing IgnoreErrors (-i / -f) test when reimporting damaged DB with certain errors prevented repair
     in all cases.


### PR DESCRIPTION
Not all DBs were repairable.  This fix addresses UNIQUE constraint failures.

Fixes: https://github.com/ChuckPa/PlexDBRepair/issues/112

Next release will add option to main menu