### PR TITLE
Set LC_ALL=C when null

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -2,12 +2,12 @@
 #########################################################################
 # Plex Media Server database check and repair utility script.           #
 # Maintainer: ChuckPa                                                   #
-# Version:    v1.10.02                                                  #
-# Date:       03-Jan-2025                                               #
+# Version:    v1.10.03                                                  #
+# Date:       17-Mar-2025                                               #
 #########################################################################
 
 # Version for display purposes
-Version="v1.10.02"
+Version="v1.10.03"
 
 # Have the databases passed integrity checks
 CheckedDB=0
@@ -61,6 +61,9 @@ STATPERMS="%a"
 
 # On all hosts except QNAP
 DFFLAGS="-m"
+
+# If LC_ALL is null,  default to C
+[ "$LC_ALL" = "" ] && export LC_ALL=C
 
 # Universal output function
 Output() {

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -8,6 +8,10 @@
 ![Maintenance](https://img.shields.io/badge/Maintained-Yes-green.svg)
 
 # Release Info:
+v1.10.03
+
+  1. LC_ALL               - When LC_ALL="", set LC_ALL=C  (MacOS now needs this)
+
 v1.10.02
 
   1. Refactor UPDATE      - QNAP BusyBox no longer support POSIX grep.  Refactored.


### PR DESCRIPTION
MacOS fails regular expressions when null (as of Sequoia)