### PR TITLE
[Windows] Check PMS state in more places

### DIFF
--- a/Windows/ReleaseNotes-Windows
+++ b/Windows/ReleaseNotes-Windows
@@ -4,6 +4,11 @@ Release notes for the Windows counterpart to DBRepair.sh (DBRepair-Windows.ps1)
 
 # Release Info
 
+v1.00.02
+  - Check whether PMS is running at more points in the process.
+  - Don't remove temp files in scripted mode if the last operation failed.
+  - Better export process that improves upon the UTF-8 fix in v1.00.01.
+
 v1.00.01
   - Bug Fix: Ensure UTF-8 characters get exported/imported properly.
 


### PR DESCRIPTION
This change does the following:

* Check whether PMS is running before each major step instead of just once.
* In script mode, don't purge temporary files if it's detected that the last repair failed.
* Refactor DB export to use `.output 'destination'" .dump` instead of piping `.dump` output to a file via PowerShell. This is a better fix for UTF8 issues that cropped up earlier.

While it likely won't fix #184 considering the batch script works, this is the best intermediate step I could find, since I wasn't able to replicate the issue across a couple different Windows systems.

I also considered integrating a file access check (via [handle](https://learn.microsoft.com/en-us/sysinternals/downloads/handle)), but I didn't like the idea of requiring an external dependency that the user has to download and add to a location on their PATH just to help diagnose what should be a rare issue.