### PR TITLE
Correct version tag handling (remove junk)

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -2,12 +2,12 @@
 #########################################################################
 # Plex Media Server database check and repair utility script.           #
 # Maintainer: ChuckPa                                                   #
-# Version:    v1.10.05                                                  #
-# Date:       20-May-2025                                               #
+# Version:    v1.10.06                                                  #
+# Date:       22-May-2025                                               #
 #########################################################################
 
 # Version for display purposes
-Version="v1.10.05"
+Version="v1.10.06"
 
 # Have the databases passed integrity checks
 CheckedDB=0
@@ -977,6 +977,8 @@ DoRepair() {
     fi
 
     # Temporary DB actions
+    Output "Performing DB cleanup tasks."
+    WriteLog "DB Cleanup tasks."
     "$PLEX_SQLITE" $CPPL.db "DELETE from statistics_bandwidth where account_id is NULL;"
 
     # Continue
@@ -1639,7 +1641,7 @@ DoUpdateTimestamp() {
 GetLatestRelease() {
   Response=$(curl -s "https://api.github.com/repos/ChuckPa/PlexDBRepair/tags")
   if [ $? -eq 0 ]; then
-    LatestVersion="$(echo "$Response" | awk -F : '{print $2}' | awk -F \, '{print $1}' | tr -d \")"
+    LatestVersion="$(echo "$Response" | awk -F : '{print $2}' | awk -F \, '{print $1}' | tr -d \" | head -3 | tail -1)"
   else
     LatestVersion="$Version"
   fi

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -8,6 +8,11 @@
 ![Maintenance](https://img.shields.io/badge/Maintained-Yes-green.svg)
 
 # Release Info:
+v1.10.06
+
+  1. Update tags          - When updating, DBRepair would not format cleanly.   This update corrects that formatting.
+                            It would often show the tags for multiple previous versions.  This is undesirable.
+
 v1.10.05
 
   1. DB Cleanup           - Temporary assist with PMS database cleanups


### PR DESCRIPTION
Users would see multiple versions' tag info.  This is undesirable.
