### PR TITLE
Fix github tag sorting

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -2,12 +2,12 @@
 #########################################################################
 # Database Repair Utility for Plex Media Server.                        #
 # Maintainer: ChuckPa                                                   #
-# Version:    v1.13.00                                                  #
-# Date:       09-Nov-2025                                               #
+# Version:    v1.13.01                                                  #
+# Date:       14-Nov-2025                                               #
 #########################################################################
 
 # Version for display purposes
-Version="v1.13.00"
+Version="v1.13.01"
 
 # Have the databases passed integrity checks
 CheckedDB=0
@@ -1891,7 +1891,7 @@ DoUpdateTimestamp() {
 GetLatestRelease() {
   Response=$(curl -sL "https://api.github.com/repos/ChuckPa/DBRepair/tags")
   if [ $? -eq 0 ]; then
-    LatestVersion="$(echo "$Response" | grep name | awk -F: '{print $2}' | sort -r | head -1 | tr -d \" | tr -d ' ' | tr -d ',')"
+    LatestVersion="$(echo "$Response" | grep name | awk -F: '{print $2}' | sort -rn | head -1 | tr -d \" | tr -d ' ' | tr -d ',')"
   else
     LatestVersion="$Version"
   fi

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -8,6 +8,11 @@
 ![Maintenance](https://img.shields.io/badge/Maintained-Yes-green.svg)
 
 # Release Info:
+v1.13.01
+
+  1. Tag sort order       - Github tags are not guaranteed to be numeric or in most-recent order.
+                            This update sorts version tags numerically and in reverse order  to accommodate github shortcoming.
+
 v1.13.00
 
   1. Binhex containers    - Add support for updated 'supervisord' start/stop control.


### PR DESCRIPTION
Github tags are not guaranteed to be numerically sorted,
Reverse sorting alone is insufficient.
Tags must be numerically sorted as well.

Fixes  https://github.com/ChuckPa/DBRepair/issues/258
